### PR TITLE
Refactor PinBlockUtil and add tests

### DIFF
--- a/src/test/java/kg/rsk/integrationmpc/util/PinBlockUtilTest.java
+++ b/src/test/java/kg/rsk/integrationmpc/util/PinBlockUtilTest.java
@@ -1,0 +1,19 @@
+package kg.rsk.integrationmpc.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PinBlockUtilTest {
+
+    @Test
+    void deriveZpkXorComponents() {
+        String result = PinBlockUtil.deriveZpk("0123456789ABCDEF", "FEDCBA9876543210");
+        assertEquals("FFFFFFFFFFFFFFFF", result);
+    }
+
+    @Test
+    void buildEncryptedPinBlockExample() throws Exception {
+        String encrypted = PinBlockUtil.buildEncryptedPinBlock("1234", "4000001234567899", "0123456789ABCDEF");
+        assertEquals("A1B8278CD8BB66F9", encrypted);
+    }
+}


### PR DESCRIPTION
## Summary
- refactor `PinBlockUtil` for clarity
- add unit test verifying ZPK derivation and encrypted PIN block generation

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685a627a73b08320b73b1a83b8186667